### PR TITLE
Use type alias

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,7 @@ impl fmt::Display for Status {
     }
 }
 
-struct StatusList {
-    elements: Vec<Status>,
-}
+type StatusList = Vec<Status>;
 
 impl StatusList {
     // TODO: make dynamic/configurable


### PR DESCRIPTION
impl is not allowed because neither the trait nor the type are defined
in this module.